### PR TITLE
Create servicedependency objects based on tags

### DIFF
--- a/examples/nagios_.jinja2
+++ b/examples/nagios_.jinja2
@@ -24,7 +24,7 @@ define {{ object_name }} {
     {% set nameparts = name.split('_') %}
     {% if nameparts[0]|lower == object_name %}
     {% if name not in envs_to_ignore %}
-    {{ name }} {{ env[name] }}
+    {{ ("_".join(nameparts[1:]))|lower }} {{ env[name]|lower }}
     {% endif %}
     {% endif %}
     {% endfor %}

--- a/examples/nagios_.jinja2
+++ b/examples/nagios_.jinja2
@@ -3,25 +3,28 @@
 {% set object_name = resource_type[7:] %}
 {% set named_object = object_name in named_objects %}
 {% for resource in resources %}
+{% set envs_to_ignore = [] %}
 {% if resource.exported %}
 {% if "only-cross-site" not in resource.tags or localsite == "false" %}
-define {{object_name}} {
+define {{ object_name }} {
     {% if named_object %}
-    {{object_name}}_name {{resource.name}}
+    {{ object_name }}_name {{ resource.name }}
     {% endif %}
-    {% for key,value in resource.parameters.items() %}
-    {% set name_key = (object_name ~ '_' ~ key)|upper %}
+    {% for key, value in resource.parameters.items() %}
     {% if key not in metaparams or key in allowed_metaparams %}
     {% if value is iterable and value is not string %}
-    {{key}} {{value|join(", ")}}
+    {{ key }} {{ value|join(", ") }}
     {% else %}
-    {% if name_key in env %}
-    {{key}} {{env[name_key]}}
-    {% elif key|upper in env %}
-    {{key}} {{env[key|upper]}}
-    {% else %}
-    {{key}} {{value}}
+    {{ key }} {{ value }}
+    {% set _ = envs_to_ignore.append((object_name ~ '_' ~ key)|upper) %}
     {% endif %}
+    {% endif %}
+    {% endfor %}
+    {% for name in env %}
+    {% set nameparts = name.split('_') %}
+    {% if nameparts[0]|lower == object_name %}
+    {% if name not in envs_to_ignore %}
+    {{ name }} {{ env[name] }}
     {% endif %}
     {% endif %}
     {% endfor %}

--- a/examples/nagios_.jinja2
+++ b/examples/nagios_.jinja2
@@ -4,6 +4,7 @@
 {% set named_object = object_name in named_objects %}
 {% for resource in resources %}
 {% if resource.exported %}
+{% if "no-cross-site" not in resource.tags %}
 {% if "garb" not in resource.name %}
 define {{object_name}} {
     {% if named_object %}
@@ -26,6 +27,7 @@ define {{object_name}} {
     {% endif %}
     {% endfor %}
 }
+{% endif %}
 {% endif %}
 {% endif %}
 {% endfor %}

--- a/examples/nagios_.jinja2
+++ b/examples/nagios_.jinja2
@@ -4,8 +4,7 @@
 {% set named_object = object_name in named_objects %}
 {% for resource in resources %}
 {% if resource.exported %}
-{% if "no-cross-site" not in resource.tags %}
-{% if "garb" not in resource.name %}
+{% if "only-cross-site" not in resource.tags or localsite == "false" %}
 define {{object_name}} {
     {% if named_object %}
     {{object_name}}_name {{resource.name}}
@@ -27,7 +26,6 @@ define {{object_name}} {
     {% endif %}
     {% endfor %}
 }
-{% endif %}
 {% endif %}
 {% endif %}
 {% endfor %}

--- a/examples/nagios_.jinja2
+++ b/examples/nagios_.jinja2
@@ -3,6 +3,8 @@
 {% set object_name = resource_type[7:] %}
 {% set named_object = object_name in named_objects %}
 {% for resource in resources %}
+{% if resource.exported %}
+{% if "garb" not in resource.name %}
 define {{object_name}} {
     {% if named_object %}
     {{object_name}}_name {{resource.name}}
@@ -24,4 +26,6 @@ define {{object_name}} {
     {% endif %}
     {% endfor %}
 }
+{% endif %}
+{% endif %}
 {% endfor %}

--- a/examples/nagios_.jinja2
+++ b/examples/nagios_.jinja2
@@ -8,11 +8,18 @@ define {{object_name}} {
     {{object_name}}_name {{resource.name}}
     {% endif %}
     {% for key,value in resource.parameters.items() %}
+    {% set name_key = (object_name ~ '_' ~ key)|upper %}
     {% if key not in metaparams or key in allowed_metaparams %}
     {% if value is iterable and value is not string %}
     {{key}} {{value|join(", ")}}
     {% else %}
+    {% if name_key in env %}
+    {{key}} {{env[name_key]}}
+    {% elif key|upper in env %}
+    {{key}} {{env[key|upper]}}
+    {% else %}
     {{key}} {{value}}
+    {% endif %}
     {% endif %}
     {% endif %}
     {% endfor %}

--- a/examples/nagios_.jinja2
+++ b/examples/nagios_.jinja2
@@ -4,7 +4,6 @@
 {% set named_object = object_name in named_objects %}
 {% for resource in resources %}
 {% if resource.exported %}
-{% if "no-cross-site" not in resource.tags %}
 {% if "garb" not in resource.name %}
 define {{object_name}} {
     {% if named_object %}
@@ -27,7 +26,6 @@ define {{object_name}} {
     {% endif %}
     {% endfor %}
 }
-{% endif %}
 {% endif %}
 {% endif %}
 {% endfor %}

--- a/puppetdb_stencil.py
+++ b/puppetdb_stencil.py
@@ -8,6 +8,7 @@ from __future__ import unicode_literals
 
 import argparse
 import logging
+import os
 import pypuppetdb
 import jinja2
 
@@ -36,7 +37,8 @@ def render_resources(database, resource_type, template_names):
         LOG.error('No template found for {0}'.format(resource_type))
     else:
         return template.render(resource_type=resource_type,
-                               resources=resources, metaparams=METAPARAMS)
+                               resources=resources, metaparams=METAPARAMS,
+                               env=os.environ)
 
 
 def main():

--- a/puppetdb_stencil.py
+++ b/puppetdb_stencil.py
@@ -24,7 +24,7 @@ ENVIRONMENT = jinja2.Environment(trim_blocks=True, lstrip_blocks=True,
                                  loader=LOADER, extensions=EXTENSIONS)
 
 
-def render_resources(database, resource_type, template_names):
+def render_resources(database, resource_type, localsite, template_names):
     """
     Render resources of the given type. They are queried from the given
     database and rendered using the first template from template_names that can
@@ -38,7 +38,7 @@ def render_resources(database, resource_type, template_names):
     else:
         return template.render(resource_type=resource_type,
                                resources=resources, metaparams=METAPARAMS,
-                               env=os.environ)
+                               env=os.environ, localsite=localsite)
 
 
 def main():
@@ -51,6 +51,7 @@ def main():
     parser.add_argument('--debug', '-d', action='store_true')
     parser.add_argument('--host', '-H', default='localhost')
     parser.add_argument('--port', '-p', default='8080')
+    parser.add_argument('--localsite', '-l', default='true')
 
     args = parser.parse_args()
     logging.basicConfig(level=logging.DEBUG if args.debug else logging.WARN)
@@ -61,7 +62,7 @@ def main():
         templates = ['{0}.jinja2'.format(resource_type)]
         if args.templates:
             templates += args.templates
-        print(render_resources(database, resource_type, templates))
+        print(render_resources(database, resource_type, args.localsite, templates))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
If a tag with the format 'parent:<parent_service_description>' exists, write a servicedependency object.
