### PR TITLE
Create servicedependency objects based on tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+virtualenv

--- a/examples/nagios_.jinja2
+++ b/examples/nagios_.jinja2
@@ -24,7 +24,7 @@ define {{ object_name }} {
     {% set nameparts = name.split('_') %}
     {% if nameparts[0]|lower == object_name %}
     {% if name not in envs_to_ignore %}
-    {{ name }} {{ env[name] }}
+    {{ ("_".join(nameparts[1:]))|lower }} {{ env[name]|lower }}
     {% endif %}
     {% endif %}
     {% endfor %}

--- a/examples/nagios_.jinja2
+++ b/examples/nagios_.jinja2
@@ -3,25 +3,28 @@
 {% set object_name = resource_type[7:] %}
 {% set named_object = object_name in named_objects %}
 {% for resource in resources %}
+{% set envs_to_ignore = [] %}
 {% if resource.exported %}
 {% if "only-cross-site" not in resource.tags or localsite == "false" %}
-define {{object_name}} {
+define {{ object_name }} {
     {% if named_object %}
-    {{object_name}}_name {{resource.name}}
+    {{ object_name }}_name {{ resource.name }}
     {% endif %}
-    {% for key,value in resource.parameters.items() %}
-    {% set name_key = (object_name ~ '_' ~ key)|upper %}
+    {% for key, value in resource.parameters.items() %}
     {% if key not in metaparams or key in allowed_metaparams %}
     {% if value is iterable and value is not string %}
-    {{key}} {{value|join(", ")}}
+    {{ key }} {{ value|join(", ") }}
     {% else %}
-    {% if name_key in env %}
-    {{key}} {{env[name_key]}}
-    {% elif key|upper in env %}
-    {{key}} {{env[key|upper]}}
-    {% else %}
-    {{key}} {{value}}
+    {{ key }} {{ value }}
+    {% set _ = envs_to_ignore.append((object_name ~ '_' ~ key)|upper) %}
     {% endif %}
+    {% endif %}
+    {% endfor %}
+    {% for name in env %}
+    {% set nameparts = name.split('_') %}
+    {% if nameparts[0]|lower == object_name %}
+    {% if name not in envs_to_ignore %}
+    {{ name }} {{ env[name] }}
     {% endif %}
     {% endif %}
     {% endfor %}

--- a/examples/nagios_.jinja2
+++ b/examples/nagios_.jinja2
@@ -4,6 +4,7 @@
 {% set named_object = object_name in named_objects %}
 {% for resource in resources %}
 {% if resource.exported %}
+{% if "no-cross-site" not in resource.tags %}
 {% if "garb" not in resource.name %}
 define {{object_name}} {
     {% if named_object %}
@@ -26,6 +27,7 @@ define {{object_name}} {
     {% endif %}
     {% endfor %}
 }
+{% endif %}
 {% endif %}
 {% endif %}
 {% endfor %}

--- a/examples/nagios_.jinja2
+++ b/examples/nagios_.jinja2
@@ -4,8 +4,7 @@
 {% set named_object = object_name in named_objects %}
 {% for resource in resources %}
 {% if resource.exported %}
-{% if "no-cross-site" not in resource.tags %}
-{% if "garb" not in resource.name %}
+{% if "only-cross-site" not in resource.tags or localsite == "false" %}
 define {{object_name}} {
     {% if named_object %}
     {{object_name}}_name {{resource.name}}
@@ -27,7 +26,6 @@ define {{object_name}} {
     {% endif %}
     {% endfor %}
 }
-{% endif %}
 {% endif %}
 {% endif %}
 {% endfor %}

--- a/examples/nagios_.jinja2
+++ b/examples/nagios_.jinja2
@@ -3,6 +3,8 @@
 {% set object_name = resource_type[7:] %}
 {% set named_object = object_name in named_objects %}
 {% for resource in resources %}
+{% if resource.exported %}
+{% if "garb" not in resource.name %}
 define {{object_name}} {
     {% if named_object %}
     {{object_name}}_name {{resource.name}}
@@ -24,4 +26,6 @@ define {{object_name}} {
     {% endif %}
     {% endfor %}
 }
+{% endif %}
+{% endif %}
 {% endfor %}

--- a/examples/nagios_.jinja2
+++ b/examples/nagios_.jinja2
@@ -8,11 +8,18 @@ define {{object_name}} {
     {{object_name}}_name {{resource.name}}
     {% endif %}
     {% for key,value in resource.parameters.items() %}
+    {% set name_key = (object_name ~ '_' ~ key)|upper %}
     {% if key not in metaparams or key in allowed_metaparams %}
     {% if value is iterable and value is not string %}
     {{key}} {{value|join(", ")}}
     {% else %}
+    {% if name_key in env %}
+    {{key}} {{env[name_key]}}
+    {% elif key|upper in env %}
+    {{key}} {{env[key|upper]}}
+    {% else %}
     {{key}} {{value}}
+    {% endif %}
     {% endif %}
     {% endif %}
     {% endfor %}

--- a/examples/nagios_.jinja2
+++ b/examples/nagios_.jinja2
@@ -1,41 +1,11 @@
-{% set allowed_metaparams = ('alias',) %}
-{% set named_objects = ('host', 'hostgroup', 'servicegroup', 'contact', 'contactgroup', 'timeperiod', 'command') %}
-{% set object_name = resource_type[7:] %}
-{% set named_object = object_name in named_objects %}
-{% set service_dependencies = {} %}
-{% for resource in resources %}
-{% set envs_to_ignore = [] %}
-{% if resource.exported %}
-{% if "only-cross-site" not in resource.tags or localsite == "false" %}
-define {{ object_name }} {
-    {% if named_object %}
-    {{ object_name }}_name {{ resource.name }}
+define {{ dto.object_name }} {
+    {% if dto.named_object %}
+    {{ dto.object_name }}_name {{ dto.name }}
     {% endif %}
-    {% for key, value in resource.parameters.items() %}
-    {% if key not in metaparams or key in allowed_metaparams %}
-    {% if value is iterable and value is not string %}
-    {{ key }} {{ value|join(", ") }}
-    {% else %}
+    {% for item in dto.parameters %}
+    {% for key, value in item.iteritems() %}
     {{ key }} {{ value }}
-    {% set _ = envs_to_ignore.append((object_name ~ '_' ~ key)|upper) %}
-    {% endif %}
-    {% endif %}
     {% endfor %}
-    {% for name in env %}
-    {% set nameparts = name.split('_') %}
-    {% if nameparts[0]|lower == object_name %}
-    {% if name not in envs_to_ignore %}
-    {{ ("_".join(nameparts[1:]))|lower }} {{ env[name]|lower }}
-    {% endif %}
-    {% endif %}
     {% endfor %}
 }
-{% for tag in resource.tags %}
-{% if 'parent:' in tag %}
-{% set parent_service_description = ':'.split(tag) %}
-# {{ parent_service_description }}
-{% endif %}
-{% endfor %}
-{% endif %}
-{% endif %}
-{% endfor %}
+

--- a/examples/nagios_.jinja2
+++ b/examples/nagios_.jinja2
@@ -2,6 +2,7 @@
 {% set named_objects = ('host', 'hostgroup', 'servicegroup', 'contact', 'contactgroup', 'timeperiod', 'command') %}
 {% set object_name = resource_type[7:] %}
 {% set named_object = object_name in named_objects %}
+{% set service_dependencies = {} %}
 {% for resource in resources %}
 {% set envs_to_ignore = [] %}
 {% if resource.exported %}
@@ -29,6 +30,12 @@ define {{ object_name }} {
     {% endif %}
     {% endfor %}
 }
+{% for tag in resource.tags %}
+{% if 'parent:' in tag %}
+{% set parent_service_description = ':'.split(tag) %}
+# {{ parent_service_description }}
+{% endif %}
+{% endfor %}
 {% endif %}
 {% endif %}
 {% endfor %}

--- a/examples/nagios_.jinja2
+++ b/examples/nagios_.jinja2
@@ -4,7 +4,6 @@
 {% set named_object = object_name in named_objects %}
 {% for resource in resources %}
 {% if resource.exported %}
-{% if "no-cross-site" not in resource.tags %}
 {% if "garb" not in resource.name %}
 define {{object_name}} {
     {% if named_object %}
@@ -27,7 +26,6 @@ define {{object_name}} {
     {% endif %}
     {% endfor %}
 }
-{% endif %}
 {% endif %}
 {% endif %}
 {% endfor %}

--- a/puppetdb_stencil.py
+++ b/puppetdb_stencil.py
@@ -8,6 +8,7 @@ from __future__ import unicode_literals
 
 import argparse
 import logging
+import os
 import pypuppetdb
 import jinja2
 
@@ -36,7 +37,8 @@ def render_resources(database, resource_type, template_names):
         LOG.error('No template found for {0}'.format(resource_type))
     else:
         return template.render(resource_type=resource_type,
-                               resources=resources, metaparams=METAPARAMS)
+                               resources=resources, metaparams=METAPARAMS,
+                               env=os.environ)
 
 
 def main():

--- a/puppetdb_stencil.py
+++ b/puppetdb_stencil.py
@@ -24,7 +24,7 @@ ENVIRONMENT = jinja2.Environment(trim_blocks=True, lstrip_blocks=True,
                                  loader=LOADER, extensions=EXTENSIONS)
 
 
-def render_resources(database, resource_type, template_names):
+def render_resources(database, resource_type, localsite, template_names):
     """
     Render resources of the given type. They are queried from the given
     database and rendered using the first template from template_names that can
@@ -38,7 +38,7 @@ def render_resources(database, resource_type, template_names):
     else:
         return template.render(resource_type=resource_type,
                                resources=resources, metaparams=METAPARAMS,
-                               env=os.environ)
+                               env=os.environ, localsite=localsite)
 
 
 def main():
@@ -51,6 +51,7 @@ def main():
     parser.add_argument('--debug', '-d', action='store_true')
     parser.add_argument('--host', '-H', default='localhost')
     parser.add_argument('--port', '-p', default='8080')
+    parser.add_argument('--localsite', '-l', default='true')
 
     args = parser.parse_args()
     logging.basicConfig(level=logging.DEBUG if args.debug else logging.WARN)
@@ -61,7 +62,7 @@ def main():
         templates = ['{0}.jinja2'.format(resource_type)]
         if args.templates:
             templates += args.templates
-        print(render_resources(database, resource_type, templates))
+        print(render_resources(database, resource_type, args.localsite, templates))
 
 
 if __name__ == '__main__':

--- a/puppetdb_stencil.py
+++ b/puppetdb_stencil.py
@@ -1,27 +1,27 @@
 #!/usr/bin/env python
+
 """
 puppetdb-stencil is a tool to render puppet resources using templates.
 """
 
 from __future__ import print_function
 from __future__ import unicode_literals
-
 import argparse
 import logging
+import sys
 import os
 import pypuppetdb
 import jinja2
 
+
 LOG = logging.getLogger('puppetdb_stencil')
-
-METAPARAMS = ('require', 'before', 'subscribe', 'notify', 'audit', 'loglevel',
-              'noop', 'schedule', 'stage', 'alias', 'tag')
-
+METAPARAMS = ('require', 'before', 'subscribe', 'notify', 'audit', 'loglevel', 'noop', 'schedule', 'stage', 'alias', 'tag')
+ALLOWED_METAPARAMS = ('alias')
+NAMED_OBJECTS = ('host', 'hostgroup', 'servicegroup', 'servicedependency', 'contact', 'contactgroup', 'timeperiod', 'command')
 # Allow templates from anywhere on the filesystem
 LOADER = jinja2.FileSystemLoader(['.', '/'])
 EXTENSIONS = ['jinja2.ext.with_', 'jinja2.ext.loopcontrols']
-ENVIRONMENT = jinja2.Environment(trim_blocks=True, lstrip_blocks=True,
-                                 loader=LOADER, extensions=EXTENSIONS)
+ENVIRONMENT = jinja2.Environment(trim_blocks=True, lstrip_blocks=True, loader=LOADER, extensions=EXTENSIONS)
 
 
 def render_resources(database, resource_type, localsite, template_names):
@@ -30,15 +30,68 @@ def render_resources(database, resource_type, localsite, template_names):
     database and rendered using the first template from template_names that can
     be loaded.
     """
-    resources = database.resources(resource_type)
+    # database.resources() is a generator, but we need to iterate it twice, so make a copy
+    r = database.resources(resource_type)
+    resources = []
     try:
         template = ENVIRONMENT.select_template(template_names)
     except jinja2.TemplatesNotFound:
         LOG.error('No template found for {0}'.format(resource_type))
     else:
-        return template.render(resource_type=resource_type,
-                               resources=resources, metaparams=METAPARAMS,
-                               env=os.environ, localsite=localsite)
+        icinga_config = ''
+        object_name = resource_type[7:]
+        named_object = object_name in NAMED_OBJECTS
+        service_dependencies = {}
+        for resource in r:
+            resources.append(resource)
+            envs_to_ignore = []
+            if resource.exported and ('only-cross-site' not in resource.tags or localsite == 'false'):
+                dto = {}
+                dto['object_name'] = object_name
+                dto['named_object'] = named_object
+                dto['name'] = resource.name
+                dto['parameters'] = []
+                # capture resource parameters from puppet
+                for key, value in resource.parameters.items():
+                    if (key not in METAPARAMS or key in ALLOWED_METAPARAMS) and (isinstance(value, list)):
+                        dto['parameters'].append({key: ','.join(value)})
+                    else:
+                        dto['parameters'].append({key: value})
+                    envs_to_ignore.append((object_name + '_' + key).upper())
+                # capture environment variable defaults
+                for name in os.environ:
+                    nameparts = name.split('_')
+                    if nameparts[0].lower() == object_name and name not in envs_to_ignore:
+                        dto['parameters'].append({'_'.join(nameparts[1:]).lower(): os.environ[name].lower()})
+                icinga_config += template.render(dto=dto) + '\n'
+            # collect child service dependencies under parent service_description
+            for tag in resource.tags:
+                if 'parent:' in tag:
+                    parent_service_description_list = tag.split(':')
+                    if len(parent_service_description_list) == 2:
+                        parent_service_description = parent_service_description_list[1]
+                        if parent_service_description not in service_dependencies:
+                            service_dependencies[parent_service_description] = []
+                        service_dependencies[parent_service_description].append(resource)
+        # render service dependencies
+        if len(service_dependencies) > 0:
+            for item in service_dependencies:
+                parent_service_description = item.replace('_', ' ')
+                # lookup parent resource by its service_description
+                for parent in resources:
+                    for key, value in parent.parameters.items():
+                        if key == 'service_description' and parent_service_description in value.lower():
+                            for child in service_dependencies[item]:
+                                dto = {}
+                                dto['object_name'] = 'servicedependency'
+                                dto['parameters'] = [{
+                                    'host_name': parent.parameters['host_name'],
+                                    'service_description': parent.parameters['service_description'],
+                                    'dependent_host_name': child.parameters['host_name'],
+                                    'dependent_service_description': child.parameters['service_description']
+                                }]
+                                icinga_config += template.render(dto=dto) + '\n'
+        return icinga_config
 
 
 def main():
@@ -52,12 +105,9 @@ def main():
     parser.add_argument('--host', '-H', default='localhost')
     parser.add_argument('--port', '-p', default='8080')
     parser.add_argument('--localsite', '-l', default='true')
-
     args = parser.parse_args()
     logging.basicConfig(level=logging.DEBUG if args.debug else logging.WARN)
-
     database = pypuppetdb.connect(host=args.host, port=args.port)
-
     for resource_type in args.resource_types:
         templates = ['{0}.jinja2'.format(resource_type)]
         if args.templates:
@@ -67,3 +117,5 @@ def main():
 
 if __name__ == '__main__':
     main()
+sys.exit(0)
+


### PR DESCRIPTION
When a resource has a tag with the form 'parent:<parent_service_description>', create a servicedependency object.
